### PR TITLE
Updated rules, improved README and fixed a small issue

### DIFF
--- a/csventrifuge.py
+++ b/csventrifuge.py
@@ -48,7 +48,7 @@ def is_valid_source(parser, arg):
 
 def is_valid_output(parser, arg):
     try:
-        output = open(arg, 'w', encoding='utf-8')
+        output = open(arg, 'w', encoding='utf-8', newline='')
     except IOError:
         parser.error('Unable to write to file {}'.format(arg))
     else:

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,23 @@ csventrifuge
 
 A flexible csv filter/rewriter, built for Luxembourg's addresses and street lists, but should be adaptable for others.
 
-sources -> obtain the values from anywhere you want
-rules -> modify values
-enhance -> add values
-filter -> drop values
+### Folder Description
 
-See `run.sh` for an example of how to use this.
+* sources -> obtain the values from anywhere you want
+* rules -> modify values
+* enhance -> add values
+* filter -> drop values
 
-To convert addresses csv to osm, open it with josm and save to csventrifuge-out.osm. Then run
+### How to use
 
-    grep -vE (luref|id_caclr_rue|commune|id_geoportail) csventrifuge-out.osm | sed -e "s/localite/addr:city/; s/id_caclr_bat/ref:caclr/; s/'rue/'addr:street/; s/numero/addr:housenumber/; s/code_postal/addr:postcode/; s/action='modify' //;" >| 2016-09-26-addresses.osm
+* Execute the utility to produce the required .csv files. See `run.sh` for an example of how to do this.
+* Open `luxembourg-addresses.csv` in [JOSM](https://josm.openstreetmap.de/), right-click the layer, select `Save As...` and save it as `csventrifuge-out.osm`. Make sure to install the [OpenData](https://wiki.openstreetmap.org/wiki/JOSM/Plugins/OpenData) plugin in JOSM first.
+* Run the following command:
+```
+grep -vE "(luref|id_caclr_rue|commune|id_geoportail)" csventrifuge-out.osm | sed -e "s/localite/addr:city/; s/id_caclr_bat/ref:caclr/; s/'rue/'addr:street/; s/numero/addr:housenumber/; s/code_postal/addr:postcode/; s/action='modify' //;" >| 2018-09-10-addresses.osm
+```
+* That's it! You can now open `2018-09-10-addresses.osm` in JOSM.
+
+### Notes
 
 Unfortunately https://github.com/pnorman/ogr2osm has https://github.com/pnorman/ogr2osm/issues/31. Pnorman recommends pre-processing in postgis.

--- a/rules/luxembourg_addresses/rue.csv
+++ b/rules/luxembourg_addresses/rue.csv
@@ -3,7 +3,9 @@ A la Siole	À la Siole
 a Pietert	A Pietert
 Aline an Emile Mayrischstrooss	Aline an Émile Mayrischstrooss
 Allée Dwight David Eisenhower	Allée Dwight D. Eisenhower
+Allée John W. Léonard	Allée John W. Leonard
 Allée St. Hubert	Allée Saint-Hubert
+Allée Saint Hubert	Allée Saint-Hubert
 Am Buurgbierg - Rés. Laurentides	Am Buurgbierg - Résidence Laurentides
 Am enneschten Eck	Am ënneschten Eck
 am Gaa	Am Gaa
@@ -11,6 +13,7 @@ Am Hueschterterboesch	Am Hueschterterbësch
 am Kalk	Am Kalk
 am Pull	Am Pull
 am Reisselt	Am Reisselt
+Am Reimergaard	Am Réimergaart
 Am Rousegaertchen	Am Rousegärtchen
 am Schank	Am Schank
 am Stach	Am Stach
@@ -24,15 +27,18 @@ An den Längten	An de Längten
 Ancien Chemin D'Osweiler	Ancien Chemin d'Osweiler
 Av. Grand-Duc Jean	Avenue Grand-Duc Jean
 Avenue Dr Ernest Feltgen	Avenue Docteur Ernest Feltgen
+Rue Dr Fernand Schwachtgen	Rue Docteur Fernand Schwachtgen
 Avenue Dr Gaasch	Avenue Docteur Gaasch
 Avenue Dr Klein	Avenue Docteur Klein
 Avenue du 31 août 1942	Avenue du 31 Août 1942
+Avenue des Villes Jumelees	Avenue des Villes Jumelées
 Avenue Emile Reuter	Avenue Émile Reuter
 Avenue J-F Kennedy	Avenue John F. Kennedy
 Avenue Marie-Adelaide	Avenue Marie-Adélaïde
 Bd Grande-Duchesse Joséphine-Charlotte	Boulevard Grande-Duchesse Joséphine-Charlotte
 Bd Robert Schuman	Boulevard Robert Schuman
 Bei den 5 Buchen	Bei de 5 Buchen
+Beim Besch	Beim Bësch
 Belle-Etoile	Belle-Étoile
 Boulevard Dr Charles Marx	Boulevard Docteur Charles Marx
 Boulevard Dr Ernest Feltgen	Boulevard Docteur Ernest Feltgen
@@ -100,6 +106,7 @@ Montée St Crépin	Montée Saint-Crépin
 Montée St Urbain	Montée Saint-Urbain
 Montée St. Hubert	Montée Saint-Hubert
 Montée St. Nicolas	Montée Saint-Nicolas
+Montée Saint Nicolas	Montée Saint-Nicolas
 Nic. Schildermans	Nicolas Schildermans
 Nonnesees	Oam Nonnesees
 om Wandhof	Om Wandhof
@@ -110,6 +117,7 @@ op der Kiert	Op der Kiert
 op der Uet	Op der Uet
 Op Feileschterkeppchen	Op Feileschter
 Op Feileschterkeppchen	Op Féilëschterkëppchen
+Op Kraeizheck	Op Kräizheck
 op Tomm	Op Tomm
 Park Drai Eechelen	Park Dräi Eechelen
 Parvis De La Basilique	Parvis de la Basilique
@@ -154,6 +162,7 @@ Rue Abbe Guill	Rue Abbé Guill
 Rue Abbe Jos Keup	Rue Abbé Jos Keup
 Rue Abbe Welter	Rue Abbé Welter
 Rue Abbé Edouard Garnich	Rue Abbé Édouard Garnich
+Rue Aline Mayrisch-de Saint-Hubert	Rue Aline Mayrisch de Saint-Hubert
 rue Aly Duhr	Rue Aly Duhr
 Rue Andre Duchscher	Rue André Duchscher
 Rue Anne Lindh	Rue Anna Lindh
@@ -167,6 +176,7 @@ Rue C.-M. Spoo	Rue Caspar Mathias Spoo
 Rue C.M. Spoo	Rue Caspar Mathias Spoo
 Rue Caspar-Mathias Spoo	Rue Caspar Mathias Spoo
 Rue Ch. W. Gluck	Rue Christoph Willibald Gluck
+Rue Charles-Frederic Mersch	Rue Charles-Frédéric Mersch
 Rue Charles-Quint	Rue Charles Quint
 rue Clas von Ehnen	Rue Clas von Ehnen
 Rue Comte Jean-Frederic D'Autel	Rue Comte Jean-Frederic d'Autel
@@ -336,6 +346,7 @@ rue Isidore Comes	Rue Isidore Comes
 Rue J-B Scharlé	Rue Jean-Baptiste Scharlé
 Rue J-F Kennedy	Rue John F. Kennedy
 Rue J-F. Kennedy	Rue John F. Kennedy
+Rue J.-B. Neuens	Rue Jean-Baptiste Neuens
 Rue J.-B. Scharlé	Rue Jean-Baptiste Scharlé
 Rue J.-F. Kennedy	Rue John F. Kennedy
 Rue J.A. Muller	Rue Joseph-Alexandre Müller
@@ -369,7 +380,7 @@ Rue Maurice Barres	Rue Maurice Barrès
 Rue Mgr. Fallize	Rue Monseigneur Fallize
 Rue Mgr. Jean Bernard	Rue Monseigneur Jean Bernard
 Rue Michel Hulsemann	Rue Michel Hülsemann
-Rue Mme Mayrisch de St Hubert	Rue Madame Mayrisch-de Saint-Hubert
+Rue Mme Mayrisch de St Hubert	Rue Madame Mayrisch de Saint-Hubert
 Rue Mont-Royal	Rue Mont Royal
 Rue Munkacsy	Rue Mihály Munkácsy
 Rue N.S. Pierret	Rue Nicolas Steffen-Pierret
@@ -443,6 +454,7 @@ Rue Wilson	Rue Woodrow Wilson
 Rue Woetzkoellchen	Rue Wëtzkëllchen
 Rue Würth-Paquet	Rue Wurth-Paquet
 Ruelle Soeur Flavia	Ruelle Sœur Flavia
+Schefflengerbierg	Schëffléngerbierg
 Schleiwegaass	Schléiwegaass
 Sentier de l'Eglise	Sentier de l'Église
 Sq. General Patton	Square General George S. Patton


### PR DESCRIPTION
Hi,
I fixed a small issue when using csventrifuge in Windows, as an extra carriage return was added, resulting in lines ending in _**\r**\r\n_ instead of _\r\n_.

I chose to set _newline=''_ instead of using the _"wb"_-mode, as I would have to change more code (we would have to write binary data instead of str). 

Tested with Python 3.6.5 (CentOS) and Python 3.7.0 (Windows 10)